### PR TITLE
<feature> Separate file system initialisation from usage

### DIFF
--- a/freemarker-wrapper/pom.xml
+++ b/freemarker-wrapper/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>freemarker-wrapper</artifactId>
     <groupId>io.codeontap</groupId>
-    <version>1.10.10</version>
+    <version>1.11</version>
     <build>
         <plugins>
             <plugin>

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/RunFreeMarker.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/RunFreeMarker.java
@@ -4,6 +4,8 @@ import freemarker.cache.FileTemplateLoader;
 import freemarker.cache.MultiTemplateLoader;
 import freemarker.template.*;
 import io.codeontap.freemarkerwrapper.files.adapters.JsonValueWrapper;
+import io.codeontap.freemarkerwrapper.files.methods.init.cmdb.InitCMDBsMethod;
+import io.codeontap.freemarkerwrapper.files.methods.init.plugin.InitPluginsMethod;
 import io.codeontap.freemarkerwrapper.files.methods.tree.cmdb.GetCMDBTreeMethod;
 import io.codeontap.freemarkerwrapper.files.methods.list.cmdb.GetCMDBsMethod;
 import io.codeontap.freemarkerwrapper.files.methods.tree.plugin.GetPluginTreeMethod;
@@ -250,6 +252,8 @@ public class RunFreeMarker {
         input.put("getCMDBs", new GetCMDBsMethod());
         input.put("getPlugins", new GetPluginsMethod());
         input.put("getPluginTree", new GetPluginTreeMethod());
+        input.put("initialiseCMDBFileSystem", new InitCMDBsMethod());
+        input.put("initialisePluginFilesystem", new InitPluginsMethod());
 
 
         Template freeMarkerTemplate = cfg.getTemplate(templateFileName);

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/RunFreeMarker.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/RunFreeMarker.java
@@ -253,7 +253,7 @@ public class RunFreeMarker {
         input.put("getPlugins", new GetPluginsMethod());
         input.put("getPluginTree", new GetPluginTreeMethod());
         input.put("initialiseCMDBFileSystem", new InitCMDBsMethod());
-        input.put("initialisePluginFilesystem", new InitPluginsMethod());
+        input.put("initialisePluginFileSystem", new InitPluginsMethod());
 
 
         Template freeMarkerTemplate = cfg.getTemplate(templateFileName);

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/meta/LayerMeta.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/meta/LayerMeta.java
@@ -20,6 +20,7 @@ public abstract class LayerMeta {
     private Integer maxDepth;
 
     private boolean caseSensitive;
+    private String filenameGlob;
 
     public String getStartingPath() {
         return startingPath;
@@ -125,5 +126,13 @@ public abstract class LayerMeta {
 
     public void setCaseSensitive(boolean caseSensitive) {
         this.caseSensitive = caseSensitive;
+    }
+
+    public String getFilenameGlob() {
+        return filenameGlob;
+    }
+
+    public void setFilenameGlob(String filenameGlob) {
+        this.filenameGlob = filenameGlob;
     }
 }

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/methods/init/InitLayersMethod.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/methods/init/InitLayersMethod.java
@@ -1,0 +1,28 @@
+package io.codeontap.freemarkerwrapper.files.methods.init;
+
+import freemarker.core.Environment;
+import freemarker.template.SimpleSequence;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import io.codeontap.freemarkerwrapper.RunFreeMarkerException;
+import io.codeontap.freemarkerwrapper.files.meta.LayerMeta;
+import io.codeontap.freemarkerwrapper.files.processors.LayerProcessor;
+
+import javax.json.JsonArray;
+
+public abstract class InitLayersMethod {
+
+    protected LayerMeta meta;
+    protected LayerProcessor layerProcessor;
+
+    public TemplateModel process() {
+        layerProcessor.setConfiguration(Environment.getCurrentEnvironment().getConfiguration());
+        JsonArray result = null;
+        try {
+            layerProcessor.initLayers(meta);
+        } catch (RunFreeMarkerException e) {
+            e.printStackTrace();
+        }
+        return new SimpleSequence(JsonArray.EMPTY_JSON_ARRAY, Environment.getCurrentEnvironment().getConfiguration().getObjectWrapper());
+    }
+}

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/methods/init/cmdb/InitCMDBsMethod.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/methods/init/cmdb/InitCMDBsMethod.java
@@ -1,0 +1,44 @@
+package io.codeontap.freemarkerwrapper.files.methods.init.cmdb;
+
+import freemarker.core.Environment;
+import freemarker.template.*;
+import io.codeontap.freemarkerwrapper.files.meta.cmdb.CMDBMeta;
+import io.codeontap.freemarkerwrapper.files.methods.init.InitLayersMethod;
+import io.codeontap.freemarkerwrapper.files.processors.cmdb.CMDBProcessor;
+
+import java.util.List;
+import java.util.Map;
+
+public class InitCMDBsMethod extends InitLayersMethod implements TemplateMethodModelEx {
+
+    public TemplateModel exec(List args) throws TemplateModelException {
+        meta = new CMDBMeta();
+        List<String> lookupDirs = (List<String>) ((DefaultListAdapter) Environment.getCurrentEnvironment().getGlobalVariable("lookupDirs")).getWrappedObject();
+        List<String> CMDBNames = (List<String>) ((DefaultListAdapter) Environment.getCurrentEnvironment().getGlobalVariable("CMDBNames")).getWrappedObject();
+        Map<String, String> cmdbPathMapping = (Map<String, String>) ((DefaultMapAdapter) Environment.getCurrentEnvironment().getGlobalVariable("cmdbPathMappings")).getWrappedObject();
+        String baseCMDB = ((SimpleScalar) Environment.getCurrentEnvironment().getGlobalVariable("baseCMDB")).getAsString();
+        TemplateHashModelEx options = (TemplateHashModelEx)args.get(0);
+        TemplateModelIterator iterator = options.keys().iterator();
+        boolean useCMDBPrefix = Boolean.FALSE;
+        boolean activeOnly = Boolean.FALSE;
+        while (iterator.hasNext()){
+            TemplateModel key = iterator.next();
+            if ("UseCMDBPrefix".equalsIgnoreCase(key.toString())){
+                useCMDBPrefix = ((TemplateBooleanModel) options.get("UseCMDBPrefix")).getAsBoolean();
+            }
+            else if ("ActiveOnly".equalsIgnoreCase(key.toString())){
+                activeOnly = ((TemplateBooleanModel) options.get("ActiveOnly")).getAsBoolean();
+            }
+        }
+        CMDBMeta cmdbMeta = (CMDBMeta)meta;
+        cmdbMeta.setLookupDirs(lookupDirs);
+        cmdbMeta.setCMDBs(cmdbPathMapping);
+        cmdbMeta.setCMDBNamesList(CMDBNames);
+        cmdbMeta.setBaseCMDB(baseCMDB);
+        cmdbMeta.setUseCMDBPrefix(useCMDBPrefix);
+        cmdbMeta.setActiveOnly(activeOnly);
+
+        layerProcessor = new CMDBProcessor();
+        return super.process();
+    }
+}

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/methods/init/plugin/InitPluginsMethod.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/methods/init/plugin/InitPluginsMethod.java
@@ -1,0 +1,24 @@
+package io.codeontap.freemarkerwrapper.files.methods.init.plugin;
+
+import freemarker.core.Environment;
+import freemarker.template.DefaultListAdapter;
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import io.codeontap.freemarkerwrapper.files.meta.plugin.PluginMeta;
+import io.codeontap.freemarkerwrapper.files.methods.init.InitLayersMethod;
+import io.codeontap.freemarkerwrapper.files.methods.list.GetLayerListMethod;
+import io.codeontap.freemarkerwrapper.files.processors.plugin.PluginProcessor;
+
+import java.util.List;
+
+public class InitPluginsMethod extends InitLayersMethod implements TemplateMethodModelEx {
+
+    public TemplateModel exec(List args) throws TemplateModelException {
+        meta = new PluginMeta();
+        List<String> pluginLayers = (List<String>) ((DefaultListAdapter) Environment.getCurrentEnvironment().getGlobalVariable("pluginLayers")).getWrappedObject();
+        ((PluginMeta)meta).setLayers(pluginLayers);
+        layerProcessor = new PluginProcessor();
+        return super.process();
+    }
+}

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/methods/list/GetLayerListMethod.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/methods/list/GetLayerListMethod.java
@@ -14,6 +14,7 @@ public abstract class GetLayerListMethod {
     protected LayerProcessor layerProcessor;
 
     public TemplateModel process() {
+        layerProcessor.setConfiguration(Environment.getCurrentEnvironment().getConfiguration());
         JsonArray result = null;
         try {
             result = layerProcessor.getLayers(meta);

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/methods/tree/GetLayerTreeMethod.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/methods/tree/GetLayerTreeMethod.java
@@ -107,6 +107,7 @@ public abstract class GetLayerTreeMethod {
     }
 
     public TemplateModel process() {
+        layerProcessor.setConfiguration(Environment.getCurrentEnvironment().getConfiguration());
         Set<JsonObject> result = null;
         try {
             result = layerProcessor.getLayerTree(meta);

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/methods/tree/GetLayerTreeMethod.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/methods/tree/GetLayerTreeMethod.java
@@ -44,6 +44,7 @@ public abstract class GetLayerTreeMethod {
         Number maxDepth = null;
         boolean includeInformation = Boolean.FALSE;
         boolean caseSensitive = Boolean.FALSE;
+        String filenameGlob = "*";
 
         while (iterator.hasNext()){
             TemplateModel key = iterator.next();
@@ -73,6 +74,8 @@ public abstract class GetLayerTreeMethod {
                 includeInformation = ((TemplateBooleanModel) options.get(key.toString())).getAsBoolean();
             } else if ("CaseSensitive".equalsIgnoreCase(key.toString())){
                 caseSensitive = ((TemplateBooleanModel) options.get(key.toString())).getAsBoolean();
+            } else if ("FilenameGlob".equalsIgnoreCase(key.toString())){
+                filenameGlob = ((SimpleScalar) options.get(key.toString())).getAsString();
             }
         }
         List<String> regexList = new ArrayList<>();
@@ -104,6 +107,7 @@ public abstract class GetLayerTreeMethod {
             meta.setMaxDepth(maxDepth.intValue());
         }
         meta.setCaseSensitive(caseSensitive);
+        meta.setFilenameGlob(filenameGlob);
     }
 
     public TemplateModel process() {

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/processors/LayerProcessor.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/processors/LayerProcessor.java
@@ -334,7 +334,7 @@ public abstract class LayerProcessor {
         if(files == null) {
             // search starting point optimisation, see https://github.com/codeontap/gen3-freemarker-wrapper/issues/22
             Path startingDir = getDirectoryOnFileSystem(meta.getStartingPath(), layer.getPath(), layer.getFileSystemPath());
-            FileFinder.Finder finder = new FileFinder.Finder("*", meta.isIgnoreDotDirectories(), meta.isIgnoreDotFiles());
+            FileFinder.Finder finder = new FileFinder.Finder(meta.getFilenameGlob(), meta.isIgnoreDotDirectories(), meta.isIgnoreDotFiles());
             String relativeLayerPath = StringUtils.substringAfter(forceUnixStyle(layer.getPath()), forceUnixStyle(meta.getStartingPath()));
             int relativeLayerPathDepth = StringUtils.split(relativeLayerPath,"/").length;
             Integer depth = Integer.MAX_VALUE;

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/processors/cmdb/CMDBProcessor.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/processors/cmdb/CMDBProcessor.java
@@ -1,5 +1,6 @@
 package io.codeontap.freemarkerwrapper.files.processors.cmdb;
 
+import freemarker.template.TemplateModelException;
 import io.codeontap.freemarkerwrapper.files.FileFinder;
 import io.codeontap.freemarkerwrapper.files.layers.Layer;
 import io.codeontap.freemarkerwrapper.files.layers.cmdb.CMDBLayer;
@@ -163,6 +164,27 @@ public class CMDBProcessor extends LayerProcessor {
         fileSystem = processCMDBFileSystem(cmdbMeta.getBaseCMDB(), buildCMDBFileSystem(
                 cmdbMeta.getBaseCMDB(), cmdbMeta.getCMDBs(), cmdbMeta.isUseCMDBPrefix(), cmdbMeta.getLayersNames(), true));
 
+        try {
+            configuration.setSharedVariable("fileSystem", fileSystem);
+            configuration.setSharedVariable("layerMap", layerMap);
+        } catch (TemplateModelException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void postProcessMeta(LayerMeta meta) {
+        CMDBMeta cmdbMeta = (CMDBMeta)meta;
+        Set<String> cmdbNames = new LinkedHashSet<>();
+        if(!cmdbMeta.getCMDBNamesList().isEmpty()){
+            if(StringUtils.isNotEmpty(cmdbMeta.getBaseCMDB()) && !cmdbMeta.getCMDBNamesList().contains(cmdbMeta.getBaseCMDB()))
+                cmdbNames.add(cmdbMeta.getBaseCMDB());
+            for (String name:cmdbMeta.getCMDBNamesList()){
+                cmdbNames.add(name);
+            }
+
+        }
+        cmdbMeta.setLayersNames(cmdbNames);
         if(cmdbMeta.getLayersNames().isEmpty()){
             for (Layer layer:layerMap.values()){
                 CMDBLayer cmdbLayer = (CMDBLayer)layer;

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/processors/plugin/PluginProcessor.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/processors/plugin/PluginProcessor.java
@@ -1,6 +1,7 @@
 package io.codeontap.freemarkerwrapper.files.processors.plugin;
 
 
+import freemarker.template.TemplateModelException;
 import io.codeontap.freemarkerwrapper.files.layers.Layer;
 import io.codeontap.freemarkerwrapper.files.meta.plugin.PluginMeta;
 import io.codeontap.freemarkerwrapper.RunFreeMarkerException;
@@ -18,7 +19,7 @@ public class PluginProcessor extends LayerProcessor {
     @Override
     public void createLayerFileSystem(LayerMeta meta) throws RunFreeMarkerException {
         PluginMeta pluginMeta = (PluginMeta) meta;
-        fileSystem = new HashMap<>();
+        fileSystem = new TreeMap<>();
 
         for (String layer : pluginMeta.getLayers()) {
             if(!Files.isDirectory(Paths.get(layer))) {
@@ -31,12 +32,19 @@ public class PluginProcessor extends LayerProcessor {
             }
         }
 
-        if (layerMap.isEmpty()) {
-            fileSystem = null;
-        } else {
+        try {
+            configuration.setSharedVariable("fileSystem", fileSystem);
+            configuration.setSharedVariable("layerMap", layerMap);
+        } catch (TemplateModelException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void postProcessMeta(LayerMeta meta) {
+        if (!layerMap.isEmpty()) {
             meta.setLayersNames(layerMap.keySet());
         }
-
     }
 
     @Override

--- a/freemarker-wrapper/src/test/java/io/codeontap/freemarkerwrapper/GetCMDBTreeMethodTest.java
+++ b/freemarker-wrapper/src/test/java/io/codeontap/freemarkerwrapper/GetCMDBTreeMethodTest.java
@@ -1663,7 +1663,7 @@ public class GetCMDBTreeMethodTest {
 
     private final String getFileTreeAccountsTemplate = "[#ftl]\n" +
             "\n" +
-            "[#assign regex=\"test.json\"]\n" +
+            "[#assign regex=\".json\"]\n" +
             "[#assign candidates =\n" +
             "  getFileTree(\n" +
             "    \"products\",\n" +
@@ -1674,6 +1674,7 @@ public class GetCMDBTreeMethodTest {
             "        \"MinDepth\" : 2,\n" +
             "        \"MaxDepth\" : 3,\n" +
             "\t\"IncludeCMDBInformation\" : true\t,\n" +
+            "\t\"FilenameGlob\" : \"test.*\"\t,\n" +
             "\t\"UseCMDBPrefix\" : false\n" +
             "    }\n" +
             "  ) ]\n" +

--- a/freemarker-wrapper/src/test/java/io/codeontap/freemarkerwrapper/GetCMDBTreeMethodTest.java
+++ b/freemarker-wrapper/src/test/java/io/codeontap/freemarkerwrapper/GetCMDBTreeMethodTest.java
@@ -1267,7 +1267,7 @@ public class GetCMDBTreeMethodTest {
         input = new HashMap<String, Object>();
         input.put("getFileTree", new GetCMDBTreeMethod());
         input.put("initialiseCMDBFileSystem", new InitCMDBsMethod());
-        input.put("initialisePluginFilesystem", new InitPluginsMethod());
+        input.put("initialisePluginFileSystem", new InitPluginsMethod());
         String fileName = templatesPath.concat("/file.ftl");
         Files.write(Paths.get(fileName), (String.format(getFileTreeAccountsTemplateMatchOptions, false, false, false, false)).getBytes());
         String content = getCMDBsAccountsTemplate;

--- a/freemarker-wrapper/src/test/java/io/codeontap/freemarkerwrapper/GetCMDBTreeMethodTest.java
+++ b/freemarker-wrapper/src/test/java/io/codeontap/freemarkerwrapper/GetCMDBTreeMethodTest.java
@@ -4,6 +4,8 @@ import freemarker.cache.FileTemplateLoader;
 import freemarker.core.Environment;
 import freemarker.template.*;
 import io.codeontap.freemarkerwrapper.files.adapters.JsonValueWrapper;
+import io.codeontap.freemarkerwrapper.files.methods.init.cmdb.InitCMDBsMethod;
+import io.codeontap.freemarkerwrapper.files.methods.init.plugin.InitPluginsMethod;
 import io.codeontap.freemarkerwrapper.files.methods.tree.cmdb.GetCMDBTreeMethod;
 import io.codeontap.freemarkerwrapper.files.methods.list.cmdb.GetCMDBsMethod;
 import io.codeontap.freemarkerwrapper.files.methods.tree.plugin.GetPluginTreeMethod;
@@ -147,6 +149,7 @@ public class GetCMDBTreeMethodTest {
         System.out.println("--------------------------- OUTPUT ---------------------------");
         System.out.write(output.getBytes());
 
+        cfg.clearSharedVariables();
         input.put("pluginLayers", Arrays.asList(new String[]{
                 pluginsPath.concat("/test/azure"),
                 pluginsPath.concat("/test/aws"),
@@ -234,6 +237,7 @@ public class GetCMDBTreeMethodTest {
         System.out.println("--------------------------- OUTPUT ---------------------------");
         System.out.write(output.getBytes());
 
+        cfg.clearSharedVariables();
         input.put("pluginLayers", Arrays.asList(new String[]{
                 pluginsPath.concat("/test/azure"),
                 pluginsPath.concat("/test/aws"),
@@ -334,6 +338,7 @@ public class GetCMDBTreeMethodTest {
         System.out.println("--------------------------- OUTPUT ---------------------------");
         System.out.write(output.getBytes());
 
+        cfg.clearSharedVariables();
         input.put("pluginLayers", Arrays.asList(new String[]{
                 pluginsPath.concat("/test/aws"),
                 pluginsPath.concat("/test/test")
@@ -357,6 +362,8 @@ public class GetCMDBTreeMethodTest {
         Assert.assertEquals(1, count);
         System.out.println("--------------------------- OUTPUT ---------------------------");
         System.out.write(output.getBytes());
+
+        cfg.clearSharedVariables();
         input.put("pluginLayers", Arrays.asList(new String[]{
                 pluginsPath.concat("/test/test"),
                 pluginsPath.concat("/test/azure"),
@@ -711,6 +718,7 @@ public class GetCMDBTreeMethodTest {
         System.out.println("--------------------------- OUTPUT ---------------------------");
         System.out.write(output.getBytes());
 
+        cfg.clearSharedVariables();
         input.put("pluginLayers", Arrays.asList(new String[]{
                 pluginsPath.concat("/test"),
                 pluginsPath.concat("/aws/"),
@@ -1258,8 +1266,10 @@ public class GetCMDBTreeMethodTest {
     public void testLookupDirOptions1() throws IOException, TemplateException {
         input = new HashMap<String, Object>();
         input.put("getFileTree", new GetCMDBTreeMethod());
+        input.put("initialiseCMDBFileSystem", new InitCMDBsMethod());
+        input.put("initialisePluginFilesystem", new InitPluginsMethod());
         String fileName = templatesPath.concat("/file.ftl");
-        Files.write(Paths.get(fileName), (String.format(getFileTreeAccountsTemplateMatchOptions, false, false)).getBytes());
+        Files.write(Paths.get(fileName), (String.format(getFileTreeAccountsTemplateMatchOptions, false, false, false, false)).getBytes());
         String content = getCMDBsAccountsTemplate;
         createFile(cmdbsPath,"accounts/path/1/test", "test.json", content);
         createFile(cmdbsPath,"api/path/2/match", "test.json", "{}");
@@ -1302,14 +1312,16 @@ public class GetCMDBTreeMethodTest {
         Assert.assertEquals(1, count);
         System.out.println("--------------------------- OUTPUT ---------------------------");
         System.out.write(output.getBytes());
+        freeMarkerTemplate.process(input, consoleWriter);
     }
 
     @Test
     public void testLookupDirOptions2() throws IOException, TemplateException {
         input = new HashMap<String, Object>();
         input.put("getFileTree", new GetCMDBTreeMethod());
+        input.put("initialiseCMDBFileSystem", new InitCMDBsMethod());
         String fileName = templatesPath.concat("/file.ftl");
-        Files.write(Paths.get(fileName), (String.format(getFileTreeAccountsTemplateMatchOptions, false, true)).getBytes());
+        Files.write(Paths.get(fileName), (String.format(getFileTreeAccountsTemplateMatchOptions, false, true, false, true)).getBytes());
         String content = getCMDBsAccountsTemplate;
         createFile(cmdbsPath,"accounts/path/1/test", "test.json", content);
         createFile(cmdbsPath,"api/path/2/match", "test.json", "{}");
@@ -1358,8 +1370,9 @@ public class GetCMDBTreeMethodTest {
     public void testLookupDirOptions3() throws IOException, TemplateException {
         input = new HashMap<String, Object>();
         input.put("getFileTree", new GetCMDBTreeMethod());
+        input.put("initialiseCMDBFileSystem", new InitCMDBsMethod());
         String fileName = templatesPath.concat("/file.ftl");
-        Files.write(Paths.get(fileName), (String.format(getFileTreeAccountsTemplateMatchOptions, true, false)).getBytes());
+        Files.write(Paths.get(fileName), (String.format(getFileTreeAccountsTemplateMatchOptions, true, false, true, false)).getBytes());
         String content = getCMDBsAccountsTemplate;
         createFile(cmdbsPath,"accounts/path/1/test", "test.json", content);
         createFile(cmdbsPath,"api/path/2/match", "test.json", "{}");
@@ -1716,6 +1729,17 @@ public class GetCMDBTreeMethodTest {
     private final String getFileTreeAccountsTemplateMatchOptions = "[#ftl]\n" +
             "\n" +
             "[#assign regex=\"match$\"]\n" +
+            "[#assign init =\n" +
+            "  initialiseCMDBFileSystem(\n" +
+            "    {\n" +
+            "        \"IgnoreDotDirectories\" : false,\n" +
+            "        \"IgnoreDotFiles\" : false,\n" +
+            "        \"StopAfterFirstMatch\" : %s,\n" +
+            "        \"IgnoreSubtreeAfterMatch\" : %s,\n" +
+            "\t\"IncludeCMDBInformation\" : true\t,\n" +
+            "\t\"UseCMDBPrefix\" : false\n" +
+            "    }\n" +
+            "  ) ]\n" +
             "[#assign candidates =\n" +
             "  getFileTree(\n" +
             "    \"/\",\n" +


### PR DESCRIPTION
fixes #24 
At present, the potentially expensive process of establishing what cmdbs/plugins are in a file system and their relationships to each other is being done as part of every call to search the file system.

To make this more efficient, introduce an explicit initialisation routine for the CMDB and Plugin file systems that must be called before any call to search the file system;

initialiseCMDBFileSystem()
initialisePluginFilesystem()

These routines can be called at any time to re-initialise the file systems, though at present there isn't a use case for this.